### PR TITLE
support for dtype

### DIFF
--- a/NPYViewer.py
+++ b/NPYViewer.py
@@ -87,56 +87,43 @@ class MainApp(QMainWindow):
 
     def openNPY(self):
         home = str(Path.home())
-        filename =  QFileDialog.getOpenFileName(self, 'Open .NPY file', home,".NPY files (*.npy);;.CSV files (*.csv)")[0]
-        data=[]
-        datafr=[]
+        filename = QFileDialog.getOpenFileName(self, 'Open .NPY file', home, ".NPY files (*.npy);;.CSV files (*.csv)")[0]
         if filename != "":
             if ".npy" in filename:
-                data=np.load(filename,allow_pickle=True)
-               # print (data)
-                #datafr = pd.DataFrame.from_records(data.tolist())
+                data = np.load(filename, allow_pickle=True)
             else:
                 data = np.array(pd.read_csv(filename).values.tolist())
 
-            npyfile=NPYfile(data,filename)
+            npyfile = NPYfile(data, filename)
             print(npyfile)
-            self.setWindowTitle('NPYViewer v.1.2:  '+npyfile.filename)
-            self.infoLb.setText("NPY Properties:\n"+str(npyfile))
+            self.setWindowTitle('NPYViewer v.1.2: ' + npyfile.filename)
+            self.infoLb.setText("NPY Properties:\n" + str(npyfile))
             self.tableWidget.clear()
 
-            rows= npyfile.data.shape[0]
-            #print(npyfile.data.shape[0][0])
-
-            if filename != ".npy" in filename:
-                self.tableWidget.setRowCount(data.shape[0])
-                if data.ndim>1:
-                    self.tableWidget.setColumnCount(data.shape[1])
-                else:
-                    self.tableWidget.setColumnCount(1)
-
+            # initialise table
+            self.tableWidget.setRowCount(data.shape[0])
+            dtype_dim = len(npyfile.data.dtype)  # 0, if plain dtype, 1 or bigger if compound dtype
+            if data.ndim > 1:
+                self.tableWidget.setColumnCount(data.shape[1])
+            elif dtype_dim > 0:
+                self.tableWidget.setColumnCount(dtype_dim)
             else:
-                if data.ndim>1:
-                    self.tableWidget.setColumnCount(data.shape[1])
-                else:
-                    self.tableWidget.setColumnCount(1)
-                print (npyfile.data)
-            if data.ndim>1:
+                self.tableWidget.setColumnCount(1)
+
+            # fill data
+            if data.ndim > 1:
                 for i, value1 in enumerate(npyfile.data):  # loop over items in first column
-                    #print (value1)
                     for j, value in enumerate(value1):
                         self.tableWidget.setItem(i, j, QTableWidgetItem(str(value)))
-                        #print(i,j)
-                        #print(value)
+            elif dtype_dim > 0:
+                for i, value1 in enumerate(npyfile.data):
+                    for j, col_name in enumerate(npyfile.data.dtype.names):
+                        self.tableWidget.setItem(i, j, QTableWidgetItem(str(value1[col_name])))
             else:
                 for i, value1 in enumerate(npyfile.data):  # loop over items in first column
                     self.tableWidget.setItem(i, 0, QTableWidgetItem(str(value1)))
 
-            self.npyfile=npyfile
-
-            #for n, value in enumerate(df['T']):  # loop over items in second column
-            #    self.data.setItem(n, 1, QTableWidgetItem(str(value)))
-
-
+            self.npyfile = npyfile
 
     def createMenu(self):
 

--- a/NPYViewer.py
+++ b/NPYViewer.py
@@ -1,3 +1,4 @@
+import os.path
 import sys
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import QIcon
@@ -87,6 +88,8 @@ class MainApp(QMainWindow):
 
     def openNPY(self):
         home = str(Path.home())
+        if self.npyfile is not None:
+            home = os.path.dirname(self.npyfile.filename)
         filename = QFileDialog.getOpenFileName(self, 'Open .NPY file', home, ".NPY files (*.npy);;.CSV files (*.csv)")[0]
         if filename != "":
             if ".npy" in filename:


### PR DESCRIPTION
Hi!
This pull request resolves #4.
If the loaded npy contains a 1d array, it will check if it has a custom/compound dtype and, if that is the case, it will display the values in separate columns. Changes are only made in openNPY() function.
Also the file dialog now remembers directory, and I cleaned up some unused code in openNPY().

I tested the samples and all of them still work with the visualization functions. Was also able to e.g. display a point cloud where the underlying data is of dtype([('x', '<f8'), ('y', '<f8'), ('z', '<f8')]).